### PR TITLE
#5 Enhancement: Allow simple change of the PL chrome <title/>

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "title": "",
   "stylesheets":["../../../css/pattern-scaffolding.css"],
   "navLinks": {
     "before": [],

--- a/dist/js/plugin-node-uiextension.js
+++ b/dist/js/plugin-node-uiextension.js
@@ -5,6 +5,8 @@ var PluginUIExtension = {
    * The function defined as the onready callback within the plugin configuration.
    */
   init: function () {
+    document.title = '/*HTML-TITLE*/';
+
     var $nav = $('#pl-pattern-nav-target');
     $nav.prepend(/*NAVLINKS-BEFORE-SNIPPET*/);
     $nav.append(/*NAVLINKS-AFTER-SNIPPET*/);

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ function pluginInit(patternlab) {
 
   //write the plugin json to public/patternlab-components
   var pluginConfig = getPluginFrontendConfig();
+  pluginConfig.title = patternlab.config.plugins[pluginName].options.title;
   pluginConfig.stylesheets = patternlab.config.plugins[pluginName].options.stylesheets;
   pluginConfig.navLinks = patternlab.config.plugins[pluginName].options.navLinks;
   pluginConfig.gearLinks = patternlab.config.plugins[pluginName].options.gearLinks;
@@ -104,6 +105,11 @@ function pluginInit(patternlab) {
           //we are also being a bit lazy here, since we only expect one file
           let uiextensionJSFileContents = fs.readFileSync(pluginFiles[i], 'utf8');
           let snippetString = '';
+
+          //customize page title
+          uiextensionJSFileContents = (pluginConfig.title && typeof(pluginConfig.title) == 'string')
+            ? fillPlaceholder(uiextensionJSFileContents, '/*HTML-TITLE*/',  pluginConfig.title)
+            : fillPlaceholder(uiextensionJSFileContents, '/*HTML-TITLE*/',  'Pattern Lab');
 
           //construct our links from the snippets
           if (pluginConfig.navLinks) {


### PR DESCRIPTION
This would allow dev to replace default page name displayed by setting a variable in `pattern-config.json` located in PL root folder.

If a string isn't found, the default page name will be displayed.